### PR TITLE
Magento logs error when Customer.list() called without filters.

### DIFF
--- a/magento/customer.py
+++ b/magento/customer.py
@@ -36,7 +36,7 @@ class Customer(API):
             Example: `{'firstname':{'ilike':'sharoon'}}`
         :return: List of dictionaries of matching records
         """
-        return self.call('customer.list', filters and [filters] or [])
+        return self.call('customer.list', filters and [filters] or [{}])
 
     def create(self, data):
         """


### PR DESCRIPTION
This isn't horribly critical but Magento logs an error message whenever the Customer.list() api call is used without filters. My solution was to pass an empty filters dict.

Here is specifics of the error:

```
errorCode: 8
errorMessage: Undefined variable: filters
errorFile: /srv/http/magento/app/code/core/Mage/Customer/Model/Customer/Api.php
errorLine: 101
```

Here is an excerpt of the code.

```
 96     public function items($filters)
 97     {
 98         $collection = Mage::getModel('customer/customer')->getCollection()
 99             ->addAttributeToSelect('*');
100
101         if (is_array($filters)) {
102             try {
103                 foreach ($filters as $field => $value) {
104                     if (isset($this->_mapAttributes[$field])) {
105                         $field = $this->_mapAttributes[$field];
106                     }
107
108                     $collection->addFieldToFilter($field, $value);
109                 }
110             } catch (Mage_Core_Exception $e) {
111                 $this->_fault('filters_invalid', $e->getMessage());
112             }
113         }
```
