### PR TITLE
getcarriers() now returns list of carriers #1905 fixes #12

### DIFF
--- a/magento/sales.py
+++ b/magento/sales.py
@@ -6,7 +6,7 @@
     to create invoices, shipments, credit memos
 
     :copyright: (c) 2010 by Sharoon Thomas.
-    :copyright: (c) 2010 by Openlabs Technologies & Consulting (P) LTD
+    :copyright: (c) 2010-2013 by Openlabs Technologies & Consulting (P) LTD
     :license: AGPLv3, see LICENSE for more details
 '''
 from .api import API
@@ -197,10 +197,8 @@ class Shipment(API):
 
         :param order_increment_id: Order ID
         """
-        return bool(
-            self.call(
-                'sales_order_shipment.getCarriers', [order_increment_id]
-            )
+        return self.call(
+            'sales_order_shipment.getCarriers', [order_increment_id]
         )
 
     #: A proxy for :meth:`getcarriers`


### PR DESCRIPTION
The getCarriers method should return the list of carriers in form of a dict but
it returns a boolean value instead.

Review: 230001
