### PR TITLE
Make the url a bytestring

### DIFF
--- a/magento/api.py
+++ b/magento/api.py
@@ -109,7 +109,7 @@ class API(object):
         """
         assert protocol \
             in PROTOCOLS, "protocol must be %s" % ' OR '.join(PROTOCOLS)
-        self.url = full_url and url or expand_url(url, protocol)
+        self.url = str(full_url and url or expand_url(url, protocol))
         self.username = username
         self.password = password
         self.protocol = protocol


### PR DESCRIPTION
The URL should be a bytestring rather than a unicode because if its a unicode then the type of msg in httplib _send_output() becomes unicode which in turn tries to concatinate message_body which is a bytestring to msg.
Here if the message_body contains a non ascii character, the concatination fails.
Hence a URL in bytestring will make sure everything remains a bytestring

Task: project-1735/task-2030
