### PR TITLE
Allow xmlrpclib.Transport subclass to be passed on initialization

### DIFF
--- a/magento/api.py
+++ b/magento/api.py
@@ -96,6 +96,8 @@ class API(object):
         :param full_url: If set to true, then the `url` is expected to
                     be a complete URL
         :param protocol: 'xmlrpc' and 'soap' are valid values
+        :param transport: optional xmlrpclib.Transport subclass for
+                    use in xmlrpc requests
         """
         assert protocol \
             in PROTOCOLS, "protocol must be %s" % ' OR '.join(PROTOCOLS)


### PR DESCRIPTION
Enable optional Transport for ServerProxy (xmlrpc based requests). 

Enables the ability to set custom headers for requests, for example, X-Forwarded-For
or User-Agent, which can be required for Magento's Session Validation.

See: Mage_Core_Model_Session_Abstract_Varien::getValidatorData
